### PR TITLE
カスタムソートのインデックスツリー取得を修正

### DIFF
--- a/app-tree-items-detail/src/app/tree-list2.service.ts
+++ b/app-tree-items-detail/src/app/tree-list2.service.ts
@@ -62,6 +62,9 @@ export class TreeList2Service {
         hrl = hostUrl+"/api/tree?action=browsing&community="+ comm_ide;
       }
 
+    }else if(urlArr[3] == "admin"){
+        hrl = hostUrl+"/api/tree";
+
     }else{
       if(moreNodes != null){
         hrl = hostUrl+"/api/tree?action=browsing&more_ids="+ moreNodes;


### PR DESCRIPTION
カスタムソート画面、一括削除画面、一括更新画面で取得するインデックスツリーを修正しました。

管理画面では、閲覧可能（browsing）なインデックスツリーを取得するのではなく、管理対象のインデックスツリーを取得する必要があります。したがって、管理画面（/admin）でインデックスツリーを取得する際に、APIのパラメータに「action=browsing」を付けないように修正しました。